### PR TITLE
Update LabelSelect.js

### DIFF
--- a/src/LabelSelect/widget/LabelSelect.js
+++ b/src/LabelSelect/widget/LabelSelect.js
@@ -85,7 +85,7 @@ mendix.widget.declare("LabelSelect.widget.LabelSelect", {
                 }
             });
             var self = this;
-            var _refreshHandle = mx.data.subscribe({
+            this._refreshHandle = mx.data.subscribe({
                     guid     : obj.getGUID(),
                     callback : function(guid) {
                         while(self.currlabelNode.childNodes.length > 1)
@@ -298,5 +298,8 @@ mendix.widget.declare("LabelSelect.widget.LabelSelect", {
 
     uninitialize : function() { 
         mx.data.unsubscribe(this._refreshHandle);
+        if (this.labelAssignInput) {
+			this.labelAssignInput.destroy();
+		}
     }
 });


### PR DESCRIPTION
The var instead of this._refreshHandle causes many subscriptions that were never closed and hang the browser for seconds due to memory leaks in case of many reference options en multiple (>5) refreshes of the main object. F5 Solved that in the browser for a while.

The destroy of the this.labelAssignInput is done because the console in 5.9.1 mentions not destroyed comboboxes in my test project.