### PR TITLE
[WC-1720] fix: isolate webpack runtime to prevent conflicts with other bundles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "LabelSelect",
-  "version": "4.5.7",
+  "version": "4.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "LabelSelect",
-  "version": "4.5.9",
+  "version": "4.6.0",
   "description": "With this widget you can easily create/assign/remove objects (for example labels) to/from an object.",
   "license": "Apache-2",
   "author": "",

--- a/src/LabelSelect/widget/LabelSelect.js
+++ b/src/LabelSelect/widget/LabelSelect.js
@@ -13,8 +13,6 @@ define([
 ], function(declare, _WidgetBase, _TemplatedMixin, dom, domClass, domStyle, domConstruct, dojoArray, lang, widgetTemplate, _jQuery) {
     "use strict";
 
-    window.jQuery = window.$ = _jQuery;
-
     require(["./lib/jquery-migrate", "jquery-ui", "jquery-ui/ui/widgets/autocomplete", "jquery-ui/ui/widgets/menu", "jquery-ui/ui/widgets/selectable", "./lib/tag-it",]);
 
     return declare("LabelSelect.widget.LabelSelect", [_WidgetBase, _TemplatedMixin], {
@@ -138,7 +136,7 @@ define([
                 value = tagObj.get(this._tagAttribute);
                 color = (this._colorAttribute) ? dom.escapeString(tagObj.get(this._colorAttribute)) : null;
 
-                $("#" + this.id + "_ListBox").tagit("createTag", value, additionalClass, duringInitialization, color);
+                _jQuery("#" + this.id + "_ListBox").tagit("createTag", value, additionalClass, duringInitialization, color);
             }, this);
 
             this._executeCallback(callback, "_renderCurrentTags");
@@ -146,11 +144,11 @@ define([
 
         _startTagger: function(options) {
             if (options) {
-                $("#" + this.id + "_ListBox").tagit(options);
+                _jQuery("#" + this.id + "_ListBox").tagit(options);
             } else {
                 //fallback
                 console.warn("No options found, running defaults");
-                $("#" + this.id + "_ListBox").tagit();
+                _jQuery("#" + this.id + "_ListBox").tagit();
             }
         },
 

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://www.mendix.com/package/1.0/">
-    <clientModule name="LabelSelect" version="4.5.9" xmlns="http://www.mendix.com/clientModule/1.0/">
+    <clientModule name="LabelSelect" version="4.6.0" xmlns="http://www.mendix.com/clientModule/1.0/">
         <widgetFiles>
             <widgetFile path="LabelSelect/LabelSelect.xml"/>
         </widgetFiles>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,8 @@ module.exports = {
         filename: `${widgetName}/widget/[name].js`,
         chunkFilename: `${widgetName}/widget/${widgetName}[id].js`,
         libraryTarget: "amd",
-        publicPath: "/widgets/"
+        publicPath: "/widgets/",
+        jsonpFunction: "label_selector_jsonp"
     },
     devtool: false,
     mode: "production",
@@ -26,6 +27,10 @@ module.exports = {
         new webpack.LoaderOptionsPlugin({ debug: true }),
         new CleanWebpackPlugin({ cleanOnceBeforeBuildPatterns: "dist/tmp" }),
         new CopyWebpackPlugin([ {context: "src", from: "**/*.{xml,css,html,png,gif}", debug: true} ], { copyUnmodified: true }),
-        new ZipPlugin({ path: `../../${widgetVersion}`, filename: widgetName, extension: "mpk" })
+        new ZipPlugin({ path: `../../${widgetVersion}`, filename: widgetName, extension: "mpk" }),
+        new webpack.ProvidePlugin({
+            $: "jquery",
+            jQuery: "jquery"
+        })
     ]
 };


### PR DESCRIPTION
Also don't patch global jquery, use webpack shimming instead.