### PR TITLE
use relative publicPath to enable flexible root url

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
         filename: `${widgetName}/widget/[name].js`,
         chunkFilename: `${widgetName}/widget/${widgetName}[id].js`,
         libraryTarget: "amd",
-        publicPath: "/widgets/",
+        publicPath: "widgets/",
         jsonpFunction: "label_selector_jsonp"
     },
     devtool: false,


### PR DESCRIPTION
Mendix Support Ticket: [https://support.mendix.com/hc/en-us/requests/226156](https://support.mendix.com/hc/en-us/requests/226156)

Hi Team,
Add this relative path to avoid importing issue of the widget when application root url is not the base domain.